### PR TITLE
Rework error and warning dialogs and group warnings. (#782)

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/UILogReceiver.java
+++ b/chunky/src/java/se/llbit/chunky/ui/UILogReceiver.java
@@ -34,31 +34,36 @@ import java.io.IOException;
 public class UILogReceiver extends Receiver {
 
   private ChunkyErrorDialog errorDialog = null;
+  private ChunkyErrorDialog warningDialog = null;
 
   @Override public void logEvent(Level level, final String message) {
+    Platform.runLater(() -> {
+      createOrGetDialogContainer(level).addMessageAndShow(message);
+    });
+  }
+
+  private ChunkyErrorDialog createOrGetDialogContainer(Level level) {
     switch (level) {
       case INFO:
       case WARNING:
-        Platform.runLater(() -> {
-          Alert warning = Dialogs.createAlert(Alert.AlertType.WARNING);
-          warning.setContentText(message);
-          warning.show();
-        });
-        break;
-      case ERROR:
-        Platform.runLater(() -> {
-          if (errorDialog == null) {
-            try {
-              errorDialog = new ChunkyErrorDialog();
-            } catch (IOException e) {
-              throw new Error("Failed to create error dialog", e);
-            }
+        if (warningDialog == null) {
+          try { 
+            warningDialog = new ChunkyErrorDialog(Level.WARNING); 
+          } catch (IOException e) { 
+            throw new Error("Failed to create warning dialog", e); 
           }
-          errorDialog.addErrorMessage(message);
-          errorDialog.show();
-        });
-        break;
+        }
+        return warningDialog;
+      case ERROR:
+      default:
+        if (errorDialog == null) {
+          try { 
+            errorDialog = new ChunkyErrorDialog(Level.ERROR); 
+          } catch (IOException e) {
+            throw new Error("Failed to create error dialog", e); 
+          }
+        }
+        return errorDialog;
     }
   }
-
 }

--- a/chunky/src/res/se/llbit/chunky/ui/WarningDialog.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/WarningDialog.fxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TabPane?>
+
+<?import javafx.scene.layout.BorderPane?>
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
+    <top>
+        <Label text="A warning occurred!&#10;&#10;Below is more information.&#10;" />
+    </top>
+    <center>
+        <TabPane fx:id="tabPane" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE" />
+    </center>
+    <padding>
+        <Insets left="10.0" right="10.0" top="10.0" />
+    </padding>
+</BorderPane>


### PR DESCRIPTION
* Reworked Error and Warning boxes.

* Error box now puts itself ontop of the chunky window. (if possible, won't let it be put behind anything else)
* Group Warnings together and use ChunkyErrorDialog object.
* Having warnings up no longer prevents the main UI from being interacted with (side effect of using Stage instead of Alert)
* Pressing escape to dismiss ChunkyErrorDialog only triggers on KeyReleased, so you wont accidentally dismiss all errors and warnings when meaning to only dismiss one of the two.
* Log.Level enum now holds its name in a final string.
* Other little bits of code cleanup.

* Apply code formatting by @NotStirred

Co-authored-by: Tom Martin <tom.martin1239@gmail.com>

* Rename error and warning windows, move the log level name into the ui code.

* Fix warning dialog being created as "Information Summary" if the first message has level INFO.

Co-authored-by: Maik Marschner <m.marschner@wertarbyte.com>
Co-authored-by: Tom Martin <tom.martin1239@gmail.com>
Co-authored-by: Maik Marschner <an@maik.tk>